### PR TITLE
Fix Windows builds by using latest npm version

### DIFF
--- a/.github/workflows/publish-native-assets-to-github-releases.yml
+++ b/.github/workflows/publish-native-assets-to-github-releases.yml
@@ -26,6 +26,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         shell: powershell
         run: |
+          npm install --global npm@latest
           npm install --global node-gyp@latest
           npm prefix -g | % {npm config set node_gyp "$_\node_modules\node-gyp\bin\node-gyp.js"}
       - name: build using node-pre-gyp


### PR DESCRIPTION
node-gyp needs to be regularly upgraded to support newer versions of Visual Studio. It seems the simplest way to achieve this is to just upgrade NPM versions to get the latest bundled node-gyp version.

Fixes #22.